### PR TITLE
fix: typo in SYNCKIT_EXEC_ARGV environment variable

### DIFF
--- a/.changeset/slow-terms-notice.md
+++ b/.changeset/slow-terms-notice.md
@@ -1,0 +1,5 @@
+---
+"synckit": patch
+---
+
+fix: typo of `SYNCKIT_EXEC_ARGV` environment variable

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ export type TsRunner = ValueOf<typeof TsRunner>
 const {
   SYNCKIT_BUFFER_SIZE,
   SYNCKIT_TIMEOUT,
-  SYNCKIT_EXEC_ARV, // kept for backwards compatibility
   SYNCKIT_EXEC_ARGV,
   SYNCKIT_TS_RUNNER,
 } = process.env
@@ -54,7 +53,7 @@ export const DEFAULT_TIMEOUT = SYNCKIT_TIMEOUT ? +SYNCKIT_TIMEOUT : undefined
 export const DEFAULT_WORKER_BUFFER_SIZE = DEFAULT_BUFFER_SIZE || 1024
 
 /* istanbul ignore next */
-export const DEFAULT_EXEC_ARGV = (SYNCKIT_EXEC_ARV || SYNCKIT_EXEC_ARGV)?.split(',') || []
+export const DEFAULT_EXEC_ARGV = SYNCKIT_EXEC_ARGV?.split(',') || []
 
 export const DEFAULT_TS_RUNNER = (SYNCKIT_TS_RUNNER ||
   TsRunner.TsNode) as TsRunner

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,8 @@ export type TsRunner = ValueOf<typeof TsRunner>
 const {
   SYNCKIT_BUFFER_SIZE,
   SYNCKIT_TIMEOUT,
-  SYNCKIT_EXEC_ARV,
+  SYNCKIT_EXEC_ARV, // kept for backwards compatibility
+  SYNCKIT_EXEC_ARGV,
   SYNCKIT_TS_RUNNER,
 } = process.env
 
@@ -53,7 +54,7 @@ export const DEFAULT_TIMEOUT = SYNCKIT_TIMEOUT ? +SYNCKIT_TIMEOUT : undefined
 export const DEFAULT_WORKER_BUFFER_SIZE = DEFAULT_BUFFER_SIZE || 1024
 
 /* istanbul ignore next */
-export const DEFAULT_EXEC_ARGV = SYNCKIT_EXEC_ARV?.split(',') || []
+export const DEFAULT_EXEC_ARGV = (SYNCKIT_EXEC_ARV || SYNCKIT_EXEC_ARGV)?.split(',') || []
 
 export const DEFAULT_TS_RUNNER = (SYNCKIT_TS_RUNNER ||
   TsRunner.TsNode) as TsRunner


### PR DESCRIPTION
I kept the typo version for backwards compatibility in case anyone was relying on it. Feel free to edit this PR.