### PR TITLE
chore: specify project package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "funding": "https://opencollective.com/unts",
   "license": "MIT",
+  "packageManager": "yarn@1.22.19",
   "engines": {
     "node": "^14.18.0 || >=16.0.0"
   },


### PR DESCRIPTION
This enables [corepack](https://github.com/nodejs/corepack) users to contribute to this repo more seamlessly (corepack will auto-install the package manager).

For non-corepack users, this tells the dev what package manager this project prefers for local development.