### PR TITLE
fix: add experimental-loader for Yarn PnP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -214,6 +215,11 @@ const setupTsRunner = (
   if (process.versions.pnp) {
     const nodeOptions = NODE_OPTIONS?.split(/\s+/)
     const pnpApiPath = cjsRequire.resolve('pnpapi')
+    const pnpLoaderPath = path.resolve(
+      path.dirname(pnpApiPath),
+      '.pnp.loader.mjs',
+    )
+
     if (
       !nodeOptions?.some(
         (option, index) =>
@@ -222,7 +228,11 @@ const setupTsRunner = (
       ) &&
       !execArgv.includes(pnpApiPath)
     ) {
-      execArgv = ['-r', pnpApiPath, ...execArgv]
+      const pnpLoaderArgv = existsSync(pnpLoaderPath)
+        ? ['--experimental-loader', pnpLoaderPath]
+        : []
+
+      execArgv = ['-r', pnpApiPath, ...pnpLoaderArgv, ...execArgv]
     }
   }
 


### PR DESCRIPTION
Adding the experimental-loader for PnP to resolve the remaining issue with loading mjs workers within synckit.

I currently don't have a test case within this repo's test suite that can demonstrate this because the difficulty is that this repo itself it not actually using Yarn PnP, and doesn't have dependencies stored within zip files. I don't yet know if writing a test case for it in this test suite is possible.

At this stage, I can only confirm that the [test script](https://github.com/un-ts/synckit/pull/98#issuecomment-1208745577) I commented about in the other PR only succeeds when run within a repo using PnP and with a patched version of synckit that includes this change.