### PR TITLE
fix: pnp loader path on Windows

### DIFF
--- a/.changeset/pnp-loader-windows-path.md
+++ b/.changeset/pnp-loader-windows-path.md
@@ -1,0 +1,6 @@
+---
+"synckit": patch
+---
+
+fix: pnp loader path on Windows
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,11 @@ const setupTsRunner = (
       execArgv = ['-r', pnpApiPath, ...execArgv]
       const pnpLoaderPath = path.resolve(pnpApiPath, '../.pnp.loader.mjs')
       if (isFile(pnpLoaderPath)) {
-        execArgv = ['--experimental-loader', pnpLoaderPath, ...execArgv]
+        // Transform path to file URL because nodejs does not accept
+        // absolute Windows paths in the --experimental-loader option.
+        // https://github.com/un-ts/synckit/issues/123
+        const experimentalLoader = pathToFileURL(pnpLoaderPath).toString()
+        execArgv = ['--experimental-loader', experimentalLoader, ...execArgv]
       }
     }
   }


### PR DESCRIPTION
Nodejs throws an ERR_UNSUPPORTED_ESM_URL_SCHEME
exception if supplying an absolute Windows path
in the `--experimental-loader` option.

This fixes #123