### PR TITLE
Improve performance by using v8 serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,12 @@ export interface GlobalShim {
 
 ### Envs
 
-1. `SYNCKIT_BUFFER_SIZE`: `bufferSize` to create `SharedArrayBuffer` for `worker_threads` (default as `1024`)
-2. `SYNCKIT_TIMEOUT`: `timeout` for performing the async job (no default)
-3. `SYNCKIT_EXEC_ARGV`: List of node CLI options passed to the worker, split with comma `,`. (default as `[]`), see also [`node` docs](https://nodejs.org/api/worker_threads.html)
-4. `SYNCKIT_TS_RUNNER`: Which TypeScript runner to be used, it could be very useful for development, could be `'ts-node' | 'esbuild-register' | 'esbuild-runner' | 'swc' | 'tsx'`, `'ts-node'` is used by default, make sure you have installed them already
-5. `SYNCKIT_GLOBAL_SHIMS`: Whether to enable the default `DEFAULT_GLOBAL_SHIMS_PRESET` as `globalShims`
+1. `SYNCKIT_BUFFER_SIZE`: Initial `bufferSize` for `SharedArrayBuffer` to transfer data from `worker_threads` (default as `1024` / 1KB)
+2. `SYNCKIT_MAX_BUFFER_SIZE`: Maximum `bufferSize` for `SharedArrayBuffer` to transfer data from `worker_threads` (default as `1024 * 1024` / 1MB)
+3. `SYNCKIT_TIMEOUT`: `timeout` for performing the async job (no default)
+4. `SYNCKIT_EXEC_ARGV`: List of node CLI options passed to the worker, split with comma `,`. (default as `[]`), see also [`node` docs](https://nodejs.org/api/worker_threads.html)
+5. `SYNCKIT_TS_RUNNER`: Which TypeScript runner to be used, it could be very useful for development, could be `'ts-node' | 'esbuild-register' | 'esbuild-runner' | 'swc' | 'tsx'`, `'ts-node'` is used by default, make sure you have installed them already
+6. `SYNCKIT_GLOBAL_SHIMS`: Whether to enable the default `DEFAULT_GLOBAL_SHIMS_PRESET` as `globalShims`
 
 ### TypeScript
 

--- a/src/SharedArrayBuffer.d.ts
+++ b/src/SharedArrayBuffer.d.ts
@@ -1,5 +1,17 @@
 // Adds definitions missing from TypeScript, this feature is available since Node.js 20
 
+interface SharedArrayBufferOptions {
+  maxByteLength?: number
+}
+
+interface SharedArrayBufferConstructor {
+  readonly prototype: SharedArrayBuffer
+  new (
+    byteLength: number,
+    options?: SharedArrayBufferOptions,
+  ): SharedArrayBuffer
+}
+
 /**
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/grow#specifications
  */
@@ -8,6 +20,11 @@ interface SharedArrayBuffer {
    * returns whether this SharedArrayBuffer can be grow or not.
    */
   readonly growable?: boolean
+
+  /**
+   * returns the maximum length (in bytes) that this SharedArrayBuffer can be grown to.
+   */
+  readonly maxByteLength?: number
 
   /**
    * grows the SharedArrayBuffer to the specified size, in bytes.

--- a/src/SharedArrayBuffer.d.ts
+++ b/src/SharedArrayBuffer.d.ts
@@ -1,0 +1,16 @@
+// Adds definitions missing from TypeScript, this feature is available since Node.js 20
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/grow#specifications
+ */
+interface SharedArrayBuffer {
+  /**
+   * returns whether this SharedArrayBuffer can be grow or not.
+   */
+  readonly growable: boolean
+
+  /**
+   * grows the SharedArrayBuffer to the specified size, in bytes.
+   */
+  grow(newLength: number): undefined
+}

--- a/src/SharedArrayBuffer.d.ts
+++ b/src/SharedArrayBuffer.d.ts
@@ -7,10 +7,10 @@ interface SharedArrayBuffer {
   /**
    * returns whether this SharedArrayBuffer can be grow or not.
    */
-  readonly growable: boolean
+  readonly growable?: boolean
 
   /**
    * grows the SharedArrayBuffer to the specified size, in bytes.
    */
-  grow(newLength: number): undefined
+  grow?(newLength: number): void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   type TransferListItem,
   Worker,
   parentPort,
+  // type-coverage:ignore-next-line -- we can't control
   workerData,
 } from 'node:worker_threads'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ export function runAsWorker<
           const buf = v8.serialize(msg)
 
           if (buf.length > sharedBuffer.byteLength) {
-            sharedBuffer.grow(buf.length)
+            sharedBuffer.grow!(buf.length)
           }
 
           buf.copy(Buffer.from(sharedBuffer), INT32_BYTES)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import { MessagePort } from 'node:worker_threads'
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFn<R = any, T extends any[] = any[]> = (...args: T) => R
 
@@ -25,10 +23,6 @@ export interface MainToWorkerMessage<T extends unknown[]> {
   sharedBuffer: SharedArrayBuffer
   id: number
   args: T
-}
-
-export interface WorkerData {
-  workerPort: MessagePort
 }
 
 export interface DataMessage<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,12 +23,12 @@ export type ValueOf<T> = T[keyof T]
 
 export interface MainToWorkerMessage<T extends unknown[]> {
   id: number
-  useBuffer: boolean
   args: T
 }
 
 export interface WorkerData {
   sharedBuffer: SharedArrayBuffer
+  useBuffer: boolean
   workerPort: MessagePort
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { MessagePort } from 'node:worker_threads'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFn<R = any, T extends any[] = any[]> = (...args: T) => R
 
@@ -21,11 +23,13 @@ export type ValueOf<T> = T[keyof T]
 
 export interface MainToWorkerMessage<T extends unknown[]> {
   id: number
+  useBuffer: boolean
   args: T
 }
 
 export interface WorkerData {
   sharedBuffer: SharedArrayBuffer
+  workerPort: MessagePort
 }
 
 export interface DataMessage<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,9 +20,12 @@ export type PromiseType<T extends AnyPromise> = T extends Promise<infer R>
 export type ValueOf<T> = T[keyof T]
 
 export interface MainToWorkerMessage<T extends unknown[]> {
-  sharedBuffer: SharedArrayBuffer
   id: number
   args: T
+}
+
+export interface WorkerData {
+  sharedBuffer: SharedArrayBuffer
 }
 
 export interface DataMessage<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,6 @@ export interface MainToWorkerMessage<T extends unknown[]> {
 
 export interface WorkerData {
   sharedBuffer: SharedArrayBuffer
-  useBuffer: boolean
   workerPort: MessagePort
 }
 


### PR DESCRIPTION
Hi @JounQin 

as promised, here is a PR that uses v8 serialization.

I tried using the same benchmark as before and it does indeed improve the performance, but not by as much as I hoped;

```
❯ node benchmark/benchmark.mjs
Load time
┌─────────┬────────────────────────┬───────────┬────────────────────┬───────────┬─────────┐
│ (index) │       Task Name        │  ops/sec  │ Average Time (ns)  │  Margin   │ Samples │
├─────────┼────────────────────────┼───────────┼────────────────────┼───────────┼─────────┤
│    0    │        'native'        │ '648 285' │ 1542.5299744942151 │ '±10.87%' │  64830  │
│    1    │ 'sync-threads (PR #3)' │ '921 905' │ 1084.7097943601377 │ '±2.76%'  │  92191  │
│    2    │ 'sync-threads (1.0.1)' │ '919 676' │ 1087.3388626049523 │ '±1.95%'  │  91968  │
│    3    │   'synckit (0.8.8)'    │ '987 481' │ 1012.6775366805905 │ '±0.82%'  │  98749  │
│    4    │     'synckit (PR)'     │ '957 444' │ 1044.4468048460658 │ '±1.75%'  │  95745  │
└─────────┴────────────────────────┴───────────┴────────────────────┴───────────┴─────────┘
Execution time
┌─────────┬────────────────────────┬───────────┬────────────────────┬───────────┬─────────┐
│ (index) │       Task Name        │  ops/sec  │ Average Time (ns)  │  Margin   │ Samples │
├─────────┼────────────────────────┼───────────┼────────────────────┼───────────┼─────────┤
│    0    │        'native'        │ '148 628' │ 6728.164121295051  │ '±2.96%'  │  14863  │
│    1    │ 'sync-threads (PR #3)' │ '11 446'  │  87365.1000610085  │ '±6.94%'  │  1145   │
│    2    │ 'sync-threads (1.0.1)' │   '795'   │ 1256925.8536821532 │ '±42.65%' │   81    │
│    3    │   'synckit (0.8.8)'    │  '1 659'  │ 602447.0128208757  │ '±34.16%' │   166   │
│    4    │     'synckit (PR)'     │  '2 249'  │ 444501.6712612576  │ '±11.02%' │   225   │
└─────────┴────────────────────────┴───────────┴────────────────────┴───────────┴─────────┘
Total time
┌─────────┬────────────────────────┬──────────┬────────────────────┬───────────┬─────────┐
│ (index) │       Task Name        │ ops/sec  │ Average Time (ns)  │  Margin   │ Samples │
├─────────┼────────────────────────┼──────────┼────────────────────┼───────────┼─────────┤
│    0    │        'native'        │ '94 942' │ 10532.723105914218 │ '±3.71%'  │  9495   │
│    1    │ 'sync-threads (PR #3)' │ '13 445' │ 74373.32819828756  │ '±1.95%'  │  1345   │
│    2    │ 'sync-threads (1.0.1)' │ '1 419'  │ 704270.0790223622  │ '±45.77%' │   168   │
│    3    │   'synckit (0.8.8)'    │ '1 340'  │ 745890.9609738517  │ '±59.90%' │   136   │
│    4    │     'synckit (PR)'     │ '2 799'  │ 357143.01722390315 │ '±7.90%'  │   280   │
└─────────┴────────────────────────┴──────────┴────────────────────┴───────────┴─────────┘
```

As you can see the performance is not as good as what I was able to get on `sync-threads`

I did not do any advanced benchmarking yet, but have one or two leads on that:
- there might be something on the amount of code/modules to load, I've seen that it has quite an impact on benchmarks
- If it were possible to reuse the `SharedArrayBuffer` between runs and not initialize a new one each time, I have the impression we could squeeze more performance out of it.
- The content of the serialized message is different between `sync-threads` and `synckit` (one more object wrapping the message) maybe this has an impact?

I can make a few more tests but I'll have to do that a bit later