### PR TITLE
fix: bump @pkgr/core to ^0.3.6 for require.extensions fix

### DIFF
--- a/.changeset/swift-pkgr-bump.md
+++ b/.changeset/swift-pkgr-bump.md
@@ -1,0 +1,5 @@
+---
+"synckit": patch
+---
+
+fix(deps): update dependency @pkgr/core to ^0.3.6

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "version": "changeset version && yarn --no-immutable"
   },
   "dependencies": {
-    "@pkgr/core": "^0.2.9"
+    "@pkgr/core": "^0.3.6"
   },
   "devDependencies": {
     "@1stg/common-config": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3723,10 +3723,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.3, @pkgr/core@npm:^0.2.4, @pkgr/core@npm:^0.2.9":
+"@pkgr/core@npm:^0.2.3, @pkgr/core@npm:^0.2.4":
   version: 0.2.9
   resolution: "@pkgr/core@npm:0.2.9"
   checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+  languageName: node
+  linkType: hard
+
+"@pkgr/core@npm:^0.3.6":
+  version: 0.3.6
+  resolution: "@pkgr/core@npm:0.3.6"
+  checksum: 10c0/153f0f4563f505faeba13c733efa0e05e467ce1c6b941055a5fd3b4560da60fbf1dff4b11da0075f034ddda11f2842b90395f60895dde5825875b616edccc11c
   languageName: node
   linkType: hard
 
@@ -14227,7 +14234,7 @@ __metadata:
     "@changesets/cli": "npm:^2.29.4"
     "@commitlint/cli": "npm:^19.8.1"
     "@oxc-node/core": "npm:^0.0.27"
-    "@pkgr/core": "npm:^0.2.9"
+    "@pkgr/core": "npm:^0.3.6"
     "@swc-node/register": "npm:^1.10.10"
     "@swc/core": "npm:^1.11.29"
     "@swc/helpers": "npm:^0.5.17"


### PR DESCRIPTION
Hi @JounQin ,

Quick fix for the `require.extensions` undefined crash that affects ESLint 10 + Yarn PnP users.

The root cause was fixed in `@pkgr/core` PR #433. This PR upgrades our dependency from `^0.2.9` to `^0.3.6` so all synckit users get the fix automatically.
